### PR TITLE
Fix Typos and Improve Documentation Across Multiple Files

### DIFF
--- a/website/docs/advanced/migrating-keys.md
+++ b/website/docs/advanced/migrating-keys.md
@@ -31,7 +31,7 @@ The migration process is straightforward and not too dissimilar to backing up an
 Exporting the slashing protection database is a real-time process and can be undertaken at any time. During migration, you should run the export once you have stopped the validator you are migrating away from. This ensures all validator actions are captured and subsequently imported into the new validator process.  
 :::
 
-To export your slashing protection history, use Prysm's built in commands which will work with any installation method.
+To export your slashing protection history, use Prysm's built-in commands which will work with any installation method.
 
 :::info
 

--- a/website/docs/advanced/migrating-keys.md
+++ b/website/docs/advanced/migrating-keys.md
@@ -194,7 +194,7 @@ You can backup validator accounts from your wallet using the following command:
 ```sh
 prysm.bat validator accounts backup
 ```
-You will now be prompted for the wallet password. Once entered, you will be guided through the backup process where you will able to select individual or all accounts to backup and the location where the backup file is created. You will also be prompted for a **"password"** for the backup file, **it is important to keep a note of this for use during the import process**. 
+You will now be prompted for the wallet password. Once entered, you will be guided through the backup process where you will be able to select individual or all accounts to backup and the location where the backup file is created. You will also be prompted for a **"password"** for the backup file, **it is important to keep a note of this for use during the import process**. 
 
 You can also run the accounts backup command non-interactively by using the following command line flags, which are also viewable by appending --help to the command line listed above:
 

--- a/website/docs/advanced/switch-clients.md
+++ b/website/docs/advanced/switch-clients.md
@@ -49,7 +49,7 @@ We have a section dedicated to exporting and importing slashing protection histo
 
 ### Step 4: Update port forwarding
 
-This step is not required for nodes which are running on a virtual public cloud, but keep in mind - nodes will be required to run a an execution client locally post merge!  
+This step is not required for nodes which are running on a virtual public cloud, but keep in mind - nodes will be required to run an execution client locally post merge!  
 
 By default, Prysm uses TCP/13000 and UDP/12000. Remove those two rules and replace them with the appropriate port forwards for the client you are switching to. The process will be very similar to the steps laid out [here.](https://docs.prylabs.network/docs/prysm-usage/p2p-host-ip#port-forwarding) 
 

--- a/website/docs/contribute/contribution-guidelines.md
+++ b/website/docs/contribute/contribution-guidelines.md
@@ -12,7 +12,7 @@ There are a number of ways to help out the project for people of all skillsets a
 
 ## Getting Started
 
-Once you are a bit more familiar with the concepts behind Ethereum and are ready to write some code, head over and explore Prysm's [open issues on Github](https://github.com/prysmaticlabs/prysm/issues). We recommend looking for issues tagged with the `Good First Issue` label if it is your first contribution. If you are still unsure about how to tackle a bug or a feature, our team is always available on [Discord](https://discord.gg/prysmaticlabs). Sign in to your Github account, then navigate to [the official Prysm repository](https://github.com/prysmaticlabs/prysm/). In the upper right hand corner of the page, click the `Fork` button. This will create a copy of the Prysm repository on your account that can be edited for pull requests.
+Once you are a bit more familiar with the concepts behind Ethereum and are ready to write some code, head over and explore Prysm's [open issues on Github](https://github.com/prysmaticlabs/prysm/issues). We recommend looking for issues tagged with the `Good First Issue` label if it is your first contribution. If you are still unsure about how to tackle a bug or a feature, our team is always available on [Discord](https://discord.gg/prysmaticlabs). Sign in to your Github account, then navigate to [the official Prysm repository](https://github.com/prysmaticlabs/prysm/). In the upper right-hand corner of the page, click the `Fork` button. This will create a copy of the Prysm repository on your account that can be edited for pull requests.
 
 ### Setting up your environment
 

--- a/website/docs/install/install-with-docker.md
+++ b/website/docs/install/install-with-docker.md
@@ -177,7 +177,7 @@ docker run -it -v $HOME/.eth2:/data -v /path/to/genesis.ssz:/genesis/genesis.ssz
 </TabItem>
 <TabItem value="win">
 
-To ensure that your Docker image has access to a data directory, mount a local drive to your container. Right click your Docker tray icon -> `Settings` -> `Shared Drives` -> select your drive -> `Apply`. Next, create a directory named `/prysm/` within your shared drive. This folder will be used as a local data directory for Prysm. This guide assumes that `C:` is the drive you've selected:
+To ensure that your Docker image has access to a data directory, mount a local drive to your container. Right-click your Docker tray icon -> `Settings` -> `Shared Drives` -> select your drive -> `Apply`. Next, create a directory named `/prysm/` within your shared drive. This folder will be used as a local data directory for Prysm. This guide assumes that `C:` is the drive you've selected:
 
 <Tabs groupId="network" defaultValue="mainnet" values={[
         {label: 'Mainnet', value: 'mainnet'},

--- a/website/docs/prysm-usage/prysmctl.md
+++ b/website/docs/prysm-usage/prysmctl.md
@@ -17,7 +17,7 @@ Binaries for the latest `prysmctl` tool can be found on the [latest prysm releas
 
 :::info
 
-Some users will need to give permissions to the downloaded binaries to be executable. Linux users can do this by right clicking the file, going to permissions, and clicking the `Allow executing file as program` checkmark. This may be different for each operating system.
+Some users will need to give permissions to the downloaded binaries to be executable. Linux users can do this by right-clicking the file, going to permissions, and clicking the `Allow executing file as program` checkmark. This may be different for each operating system.
 
 :::
 

--- a/website/docs/prysm-usage/slasher.md
+++ b/website/docs/prysm-usage/slasher.md
@@ -45,7 +45,7 @@ A validator that correctly follows the protocol should never emit a slashable vo
 
 ## What is a Slasher
 
-**Slasher** is the name of software that can detect slashable events from validators and report them to the protocol. You can think of a slasher as the network “police”. Running a slasher is **optional**. In order to detect slashable messages, the slasher records the attesting and proposing history for every validator on the network, then cross references this history with what has been broadcasted to find slashable messages such as double blocks or surrounding votes.
+**Slasher** is the name of software that can detect slashable events from validators and report them to the protocol. You can think of a slasher as the network “police”. Running a slasher is **optional**. In order to detect slashable messages, the slasher records the attesting and proposing history for every validator on the network, then cross-references this history with what has been broadcasted to find slashable messages such as double blocks or surrounding votes.
 
 In theory all the network needs is *1 honest, properly functioning slasher* to monitor the network because any slashings found are propagated to the entire network for it to be put into a block as soon as possible.
 


### PR DESCRIPTION
This PR addresses various typographical issues across multiple documentation files, including:

- Corrected hyphenation in compound adjectives such as "built-in" and "right-clicking".
- Fixed grammatical errors such as missing words and articles (e.g., "will be able" instead of "will able").
- Adjusted formatting for clarity and consistency, including the use of "cross-references" with a hyphen.

Files affected:
- `migrating-keys.md`
- `switch-clients.md`
- `contribution-guidelines.md`
- `install-with-docker.md`
- `prysmctl.md`
- `slasher.md`

These updates aim to improve the readability and correctness of the documentation.
